### PR TITLE
Revert "Update Go module name"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/saladtechnologies/oras-go
+module oras.land/oras-go/v2
 
 go 1.21
 


### PR DESCRIPTION
This reverts commit 6668049879996bf82160b87c56bb0d83464db666.

If we leave the name alone replace will work properly in the
project's go.mod.  go get breaks when changing the pinned
version/commit but can be worked around by updating the
version in the replace line.