### PR TITLE
[RD] Add Salad's resumable download patches

### DIFF
--- a/README.Salad.md
+++ b/README.Salad.md
@@ -20,3 +20,7 @@ for `oras-go`.
   * AnnotationResume* - the keys used in the Annotations[] map
     * The Annotations field of the Descriptor is used to pass state around during the request handling.  This avoids changing the public API via interfaces or structs.
     * Salad-specific keys are defined in `internal/spec/artifact.go` using constants with names beginning with `AnnotationResume`.
+
+* `content.hashVerifier` (new) (`content/verifiers.go`)
+  * `digest.hashVerifier` is copied here from `opencontainers/go-digest/blob/master/verifiers.go`
+    because it is private and we need to construct a verifier with our new `Hash` and the original `Digest`.

--- a/README.Salad.md
+++ b/README.Salad.md
@@ -66,6 +66,10 @@ for `oras-go`.
     * TRUE:
       * call `ioutil.CopyBuffer()` as usual
 
+* `ioutil.CopyBuffer()` (`internal/ioutil.io.go`)
+  * call `content.NewVerifyReader()` as usual
+  * handle `io.ErrUnexpectedEOF`: check `bytes read == desc.Size - ingestSize`
+
 * `content.NewVerifyReader()` (`content/reader.go`)
   * Add `resume` field to `VerifyReader` struct
   * if `Annotations[offset]` > 0

--- a/README.Salad.md
+++ b/README.Salad.md
@@ -21,6 +21,35 @@ for `oras-go`.
     * The Annotations field of the Descriptor is used to pass state around during the request handling.  This avoids changing the public API via interfaces or structs.
     * Salad-specific keys are defined in `internal/spec/artifact.go` using constants with names beginning with `AnnotationResume`.
 
+* `remote.FetcherHead` (`registry/remote/repository.go`)
+  * interface defining `FetchHead()`
+
+* `remote.BlobStoreHead` (`registry/remote/repository.go`)
+  * interface combining `registry.BlobStore` with `FetcherHead`
+
+* `remote.Repository.FetchHead()` (new) (`registry/remote/repository.go`)
+  * call `FetchHead()` when `BlobStoreHead` is implemented
+
+* `remote.blobStore` (`registry/remote/repository.go`)
+  * `blobStore.Fetch()`
+    * call `FetchHead()` to check for the `Range` header support from the server
+      * FALSE:
+        * reset resume flag and proceed as usual
+      * TRUE:
+        * Set `Range` header
+    * after GET request to remote repository if in resume
+      * `StatusPartialContent`:
+        * check response `ContentLength` against `target.Size - ingestSize`
+      * `StatusOK`:
+        * check response `ContentLength` against `target.Size`
+  * `blobStore.FetchHead()` (new)
+    * do HEAD call to src
+      * `StatusOK`:
+        * check response `ContentLength` against `target.Size`
+        * check response header `Accept-Ranges` has value `bytes`
+          * TRUE:
+            * Set resume flag
+
 * `content.Storage.Push()` (`content/oci/storage.go`)
   * call `Storage.ingest()` as usual
 

--- a/README.Salad.md
+++ b/README.Salad.md
@@ -21,6 +21,15 @@ for `oras-go`.
     * The Annotations field of the Descriptor is used to pass state around during the request handling.  This avoids changing the public API via interfaces or structs.
     * Salad-specific keys are defined in `internal/spec/artifact.go` using constants with names beginning with `AnnotationResume`.
 
+* `content.NewVerifyReader()` (`content/reader.go`)
+  * Add `resume` field to `VerifyReader` struct
+  * if `Annotations[offset]` > 0
+    * TRUE:
+      * decode `Annotations[Hash]`
+      * create a new `content.hashVerifier` with the new `Hash` and the original `desc.Digest`
+    * FALSE:
+      * create a new `digest.hashVerifier` from `desc.Digest`
+
 * `content.hashVerifier` (new) (`content/verifiers.go`)
   * `digest.hashVerifier` is copied here from `opencontainers/go-digest/blob/master/verifiers.go`
     because it is private and we need to construct a verifier with our new `Hash` and the original `Digest`.

--- a/README.Salad.md
+++ b/README.Salad.md
@@ -1,0 +1,22 @@
+# Salad Extension to ORAS Go Library
+
+## TL;DR
+
+The cost of failed downloads being restarted by deleting partially downloaded layers
+is a high one to pay in the Salad network especially when some of these layers may exceed
+10GB.  Resuming partial downloads is an important part of a robust and resilient and
+performant distributed compute node with limited bandwidth.
+
+This repository is a fork of https://github.com/oras-project/oras-go/ just after the v2.5.0
+tag.  The branch `resume` contains Salad's download changes.  The only changes required to
+build the ORAS CLI (`oras`) (https://github.com/oras-project/oras) are to use this replacement
+for `oras-go`.
+
+## Summary
+
+### Changes
+
+* `Annotations` key constants (`internal/spec/artifact.go`)
+  * AnnotationResume* - the keys used in the Annotations[] map
+    * The Annotations field of the Descriptor is used to pass state around during the request handling.  This avoids changing the public API via interfaces or structs.
+    * Salad-specific keys are defined in `internal/spec/artifact.go` using constants with names beginning with `AnnotationResume`.

--- a/content/oci/oci.go
+++ b/content/oci/oci.go
@@ -155,6 +155,11 @@ func (s *Store) Exists(ctx context.Context, target ocispec.Descriptor) (bool, er
 	return s.storage.Exists(ctx, target)
 }
 
+// Get the ingest file matching name from the storage layer
+func (s *Store) IngestFile(name string) string {
+	return s.storage.IngestFile(name)
+}
+
 // Delete deletes the content matching the descriptor from the store. Delete may
 // fail on certain systems (i.e. NTFS), if there is a process (i.e. an unclosed
 // Reader) using target. If s.AutoGC is set to true, Delete will recursively

--- a/content/oci/storage.go
+++ b/content/oci/storage.go
@@ -23,11 +23,14 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/ioutil"
+	"oras.land/oras-go/v2/internal/spec"
 )
 
 // bufPool is a pool of byte buffers that can be reused for copying content
@@ -107,6 +110,18 @@ func (s *Storage) Push(_ context.Context, expected ocispec.Descriptor, content i
 	return nil
 }
 
+// IngestFile returns the ingest file matching name
+func (s *Storage) IngestFile(name string) string {
+	ingestFiles, err := filepath.Glob(filepath.Join(s.ingestRoot, name+"_*"))
+	if err != nil || len(ingestFiles) == 0 {
+		// Error or no files found
+		return ""
+	}
+	// Found at least one file, return up the first one
+	// TODO: Look for the largest matching file?
+	return ingestFiles[0]
+}
+
 // Delete removes the target from the system.
 func (s *Storage) Delete(ctx context.Context, target ocispec.Descriptor) error {
 	path, err := blobPath(target.Digest)
@@ -125,18 +140,59 @@ func (s *Storage) Delete(ctx context.Context, target ocispec.Descriptor) error {
 }
 
 // ingest write the content into a temporary ingest file.
-func (s *Storage) ingest(expected ocispec.Descriptor, content io.Reader) (path string, ingestErr error) {
+func (s *Storage) ingest(expected ocispec.Descriptor, contentReader io.Reader) (path string, ingestErr error) {
 	if err := ensureDir(s.ingestRoot); err != nil {
 		return "", fmt.Errorf("failed to ensure ingest dir: %w", err)
 	}
 
-	// create a temp file with the file name format "blobDigest_randomString"
-	// in the ingest directory.
-	// Go ensures that multiple programs or goroutines calling CreateTemp
-	// simultaneously will not choose the same file.
-	fp, err := os.CreateTemp(s.ingestRoot, expected.Digest.Encoded()+"_*")
+	// Resume Download
+	resume := expected.Annotations[spec.AnnotationResumeDownload]
+	ingestFile := expected.Annotations[spec.AnnotationResumeFilename]
+	ingestSize, err := strconv.ParseInt(expected.Annotations[spec.AnnotationResumeOffset], 10, 64)
 	if err != nil {
-		return "", fmt.Errorf("failed to create ingest file: %w", err)
+		ingestSize = 0
+	}
+
+	// See if a partial ingest file with this hash already exists
+	var fp *os.File
+	if resume == "true" && ingestFile != "" && ingestSize > 0 && ingestSize < expected.Size {
+		// Found a suitable ingest file
+		fp, err = os.OpenFile(ingestFile, os.O_RDWR|os.O_APPEND, 0o600)
+		if err != nil {
+			return "", fmt.Errorf("failed to open partial ingest file: %w", err)
+		}
+
+		// Rewind file to re-verify current contents on disk
+		fp.Seek(0, io.SeekStart)
+
+		// Make a new Hash and update for current contents on disk
+		newHash := expected.Digest.Algorithm().Hash()
+		if n, err := io.Copy(newHash, fp); err != nil || n != ingestSize {
+			// If error, assume we can't use what is there
+			ingestSize = 0
+		} else {
+			eh, err := content.EncodeHash(newHash)
+			if err != nil {
+				// oops, still can't resume...
+				ingestSize = 0
+			} else {
+				expected.Annotations[spec.AnnotationResumeHash] = eh
+			}
+		}
+		if ingestSize == 0 {
+			// Reset file pointer
+			fp.Seek(0, io.SeekStart)
+		}
+	} else {
+		// No partial ingest files found
+		// create a temp file with the file name format "blobDigest_randomString"
+		// in the ingest directory.
+		// Go ensures that multiple programs or goroutines calling CreateTemp
+		// simultaneously will not choose the same file.
+		fp, err = os.CreateTemp(s.ingestRoot, expected.Digest.Encoded()+"_*")
+		if err != nil {
+			return "", fmt.Errorf("failed to create ingest file: %w", err)
+		}
 	}
 
 	path = fp.Name()
@@ -149,10 +205,13 @@ func (s *Storage) ingest(expected ocispec.Descriptor, content io.Reader) (path s
 	}()
 	defer fp.Close()
 
-	buf := bufPool.Get().(*[]byte)
-	defer bufPool.Put(buf)
-	if err := ioutil.CopyBuffer(fp, content, *buf, expected); err != nil {
-		return "", fmt.Errorf("failed to ingest: %w", err)
+	// Copy downloaded bits to ingest file only if we do not already have it all
+	if ingestSize >= 0 && ingestSize < expected.Size {
+		buf := bufPool.Get().(*[]byte)
+		defer bufPool.Put(buf)
+		if err := ioutil.CopyBuffer(fp, contentReader, *buf, expected); err != nil {
+			return "", fmt.Errorf("failed to ingest: %w", err)
+		}
 	}
 
 	// change to readonly

--- a/content/reader.go
+++ b/content/reader.go
@@ -16,12 +16,18 @@ limitations under the License.
 package content
 
 import (
+	"crypto/sha256"
+	"encoding"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
+	"strconv"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/internal/spec"
 )
 
 var (
@@ -51,6 +57,7 @@ type VerifyReader struct {
 	verifier digest.Verifier
 	verified bool
 	err      error
+	resume   bool
 }
 
 // Read reads up to len(p) bytes into p. It returns the number of bytes
@@ -62,7 +69,7 @@ func (vr *VerifyReader) Read(p []byte) (n int, err error) {
 
 	n, err = vr.base.Read(p)
 	if err != nil {
-		if err == io.EOF && vr.base.N > 0 {
+		if err == io.EOF && vr.base.N > 0 && !vr.resume {
 			err = io.ErrUnexpectedEOF
 		}
 		vr.err = err
@@ -99,7 +106,28 @@ func (vr *VerifyReader) Verify() error {
 
 // NewVerifyReader wraps r for reading content with verification against desc.
 func NewVerifyReader(r io.Reader, desc ocispec.Descriptor) *VerifyReader {
-	verifier := desc.Digest.Verifier()
+	var verifier digest.Verifier
+
+	// Ignore error, if we can't parse it assume zero
+	offset, _ := strconv.ParseInt(desc.Annotations[spec.AnnotationResumeOffset], 10, 64)
+
+	// All error cases below fall through to create a digest.Verifier
+	if offset > 0 {
+		// Attempt to resume
+		newHash, err := DecodeHash(desc.Annotations[spec.AnnotationResumeHash], desc.Digest)
+		if err == nil {
+			// Create a verifier with our in-progress hash and the final digest
+			verifier = hashVerifier{
+				hash:   newHash,
+				digest: desc.Digest,
+			}
+		}
+	}
+	if verifier == nil {
+		// Did not get a verifier for resume, make a new empty one
+		verifier = desc.Digest.Verifier()
+	}
+
 	lr := &io.LimitedReader{
 		R: io.TeeReader(r, verifier),
 		N: desc.Size,
@@ -107,6 +135,7 @@ func NewVerifyReader(r io.Reader, desc ocispec.Descriptor) *VerifyReader {
 	return &VerifyReader{
 		base:     lr,
 		verifier: verifier,
+		resume:   offset > 0,
 	}
 }
 
@@ -122,6 +151,10 @@ func ReadAll(r io.Reader, desc ocispec.Descriptor) ([]byte, error) {
 	vr := NewVerifyReader(r, desc)
 	if n, err := io.ReadFull(vr, buf); err != nil {
 		if errors.Is(err, io.ErrUnexpectedEOF) {
+			if err == io.ErrUnexpectedEOF && vr.base.N > 0 && vr.resume {
+				// In resume mode the buffers may not be exact
+				err = io.EOF
+			}
 			return nil, fmt.Errorf("read failed: expected content size of %d, got %d, for digest %s: %w", desc.Size, n, desc.Digest.String(), err)
 		}
 		return nil, fmt.Errorf("read failed: %w", err)
@@ -141,4 +174,36 @@ func ensureEOF(r io.Reader) error {
 		return ErrTrailingData
 	}
 	return nil
+}
+
+// DecodeHash recovers a Hash object from existing partial data
+func DecodeHash(encHash string, d digest.Digest) (hash.Hash, error) {
+	state, err := hex.DecodeString(encHash)
+	if err == nil {
+		// Recover Hash object
+		newHash := d.Algorithm().Hash()
+		unmarshaler, ok := newHash.(encoding.BinaryUnmarshaler)
+		if ok {
+			if err := unmarshaler.UnmarshalBinary(state); err == nil {
+				return newHash, nil
+			}
+		}
+	}
+	// Return new empty Hash with error
+	return sha256.New(), err
+}
+
+// EncodeHash serialzes a Hash object to pass to a Verifier
+func EncodeHash(h hash.Hash) (string, error) {
+	marshaler, ok := h.(encoding.BinaryMarshaler)
+	if ok {
+		state, err := marshaler.MarshalBinary()
+		if err == nil {
+			// Save the new Hash as an Annotation to pass to the Verifier
+			buf := make([]byte, hex.EncodedLen(len(state)))
+			hex.Encode(buf, state)
+			return string(buf), nil
+		}
+	}
+	return "", fmt.Errorf("error encoding Hash")
 }

--- a/content/reader_test.go
+++ b/content/reader_test.go
@@ -20,11 +20,64 @@ import (
 	_ "crypto/sha256"
 	"errors"
 	"io"
+	"reflect"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/internal/spec"
 )
+
+func TestVerifyReader_NewVerifyReader(t *testing.T) {
+	content := []byte("example content")
+
+	// Default no-resume path
+	r := bytes.NewReader(content)
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromBytes(content),
+		Size:      int64(len(content) + 1),
+	}
+	vr := NewVerifyReader(r, desc)
+	if vr.resume {
+		t.Fatalf("resume is set: %s", desc.Annotations)
+	}
+
+	// Resume is enabled and we expect to read something
+	r = bytes.NewReader(content)
+	desc = ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromBytes(content),
+		Size:      int64(len(content) + 1),
+		Annotations: map[string]string{
+			spec.AnnotationResumeDownload: "true",
+			spec.AnnotationResumeOffset:   "3",
+		},
+	}
+	vr = NewVerifyReader(r, desc)
+	if !vr.resume {
+		t.Fatalf("resume is not set: %+v", desc.Annotations)
+	}
+
+	// Resume is enabled and we expect to read something with hash
+	d := digest.FromBytes(content)
+	h, _ := EncodeHash(d.Algorithm().Hash())
+	r = bytes.NewReader(content)
+	desc = ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    d,
+		Size:      int64(len(content) + 1),
+		Annotations: map[string]string{
+			spec.AnnotationResumeDownload: "true",
+			spec.AnnotationResumeOffset:   "3",
+			spec.AnnotationResumeHash:     h,
+		},
+	}
+	vr = NewVerifyReader(r, desc)
+	if !vr.resume {
+		t.Fatalf("resume is not set: %+v", desc.Annotations)
+	}
+}
 
 func TestVerifyReader_Read(t *testing.T) {
 	// matched content and descriptor with small buffer
@@ -64,6 +117,57 @@ func TestVerifyReader_Read(t *testing.T) {
 	// mismatched content and descriptor with sufficient buffer
 	r = bytes.NewReader([]byte("bar"))
 	vr = NewVerifyReader(r, desc)
+	buf = make([]byte, 5)
+	n, err = vr.Read(buf)
+	if err != nil {
+		t.Fatal("Read() error = ", err)
+	}
+	if n != 3 {
+		t.Fatalf("incorrect number of bytes read: %d", n)
+	}
+}
+
+func TestVerifyReader_Read_Resume(t *testing.T) {
+	// matched content and descriptor with small buffer
+	content := []byte("example content")
+	desc := NewDescriptorFromBytes("test", content)
+	r := bytes.NewReader(content)
+	vr := NewVerifyReader(r, desc)
+	vr.resume = true
+	buf := make([]byte, 5)
+	n, err := vr.Read(buf)
+	if err != nil {
+		t.Fatal("Read() error = ", err)
+	}
+	if !bytes.Equal(buf, []byte("examp")) {
+		t.Fatalf("incorrect read content: %s", buf)
+	}
+	if n != 5 {
+		t.Fatalf("incorrect number of bytes read: %d", n)
+	}
+
+	// matched content and descriptor with sufficient buffer
+	content = []byte("foo foo")
+	desc = NewDescriptorFromBytes("test", content)
+	r = bytes.NewReader(content)
+	vr = NewVerifyReader(r, desc)
+	vr.resume = true
+	buf = make([]byte, len(content))
+	n, err = vr.Read(buf)
+	if err != nil {
+		t.Fatal("Read() error = ", err)
+	}
+	if n != len(content) {
+		t.Fatalf("incorrect number of bytes read: %d", n)
+	}
+	if !bytes.Equal(buf, content) {
+		t.Fatalf("incorrect read content: %s", buf)
+	}
+
+	// mismatched content and descriptor with sufficient buffer
+	r = bytes.NewReader([]byte("bar"))
+	vr = NewVerifyReader(r, desc)
+	vr.resume = true
 	buf = make([]byte, 5)
 	n, err = vr.Read(buf)
 	if err != nil {
@@ -149,9 +253,131 @@ func TestVerifyReader_Verify(t *testing.T) {
 	}
 }
 
+func TestVerifyReader_Verify_Resume(t *testing.T) {
+	// matched content and descriptor
+	content := []byte("example content")
+	desc := ocispec.Descriptor{
+		MediaType: "test",
+		Digest:    digest.FromBytes(content),
+		Size:      int64(len(content)),
+		Annotations: map[string]string{
+			spec.AnnotationResumeDownload: "true",
+			spec.AnnotationResumeOffset:   "3",
+		},
+	}
+	r := bytes.NewReader(content)
+	vr := NewVerifyReader(r, desc)
+	buf := make([]byte, len(content))
+	if _, err := vr.Read(buf); err != nil {
+		t.Fatal("Read() error = ", err)
+	}
+	if err := vr.Verify(); err != nil {
+		t.Fatal("Verify() error = ", err)
+	}
+	if !bytes.Equal(buf, content) {
+		t.Fatalf("incorrect read content: %s", buf)
+	}
+
+	// mismatched content and descriptor, read size larger than descriptor size
+	content = []byte("foo")
+	r = bytes.NewReader(content)
+	desc = ocispec.Descriptor{
+		MediaType: "test",
+		Digest:    digest.FromBytes(content),
+		Size:      int64(len(content) - 1),
+		Annotations: map[string]string{
+			spec.AnnotationResumeDownload: "true",
+			spec.AnnotationResumeOffset:   "3",
+		},
+	}
+	vr = NewVerifyReader(r, desc)
+	buf = make([]byte, len(content))
+	if _, err := vr.Read(buf); err != nil {
+		t.Fatal("Read() error = ", err)
+	}
+	if err := vr.Verify(); !errors.Is(err, ErrTrailingData) {
+		t.Fatalf("Verify() error = %v, want %v", err, ErrTrailingData)
+	}
+	// call vr.Verify again, the result should be the same
+	if err := vr.Verify(); !errors.Is(err, ErrTrailingData) {
+		t.Fatalf("2nd Verify() error = %v, want %v", err, ErrTrailingData)
+	}
+
+	// mismatched content and descriptor, read size smaller than descriptor size
+	content = []byte("foo")
+	r = bytes.NewReader(content)
+	desc = ocispec.Descriptor{
+		MediaType: "test",
+		Digest:    digest.FromBytes(content),
+		Size:      int64(len(content) + 1),
+		Annotations: map[string]string{
+			spec.AnnotationResumeDownload: "true",
+			spec.AnnotationResumeOffset:   "3",
+		},
+	}
+	vr = NewVerifyReader(r, desc)
+	buf = make([]byte, len(content))
+	if _, err := vr.Read(buf); err != nil {
+		t.Fatal("Read() error = ", err)
+	}
+	if err := vr.Verify(); !errors.Is(err, errEarlyVerify) {
+		t.Fatalf("Verify() error = %v, want %v", err, errEarlyVerify)
+	}
+	// call vr.Verify again, the result should be the same
+	if err := vr.Verify(); !errors.Is(err, errEarlyVerify) {
+		t.Fatalf("Verify() error = %v, want %v", err, errEarlyVerify)
+	}
+
+	// mismatched content and descriptor, wrong digest
+	content = []byte("bar")
+	r = bytes.NewReader(content)
+	desc = ocispec.Descriptor{
+		MediaType: "test",
+		Digest:    digest.FromBytes([]byte("foo")),
+		Size:      int64(len(content)),
+		Annotations: map[string]string{
+			spec.AnnotationResumeDownload: "true",
+			spec.AnnotationResumeOffset:   "3",
+		},
+	}
+	vr = NewVerifyReader(r, desc)
+	buf = make([]byte, len(content))
+	if _, err := vr.Read(buf); err != nil {
+		t.Fatal("Read() error = ", err)
+	}
+	if err := vr.Verify(); !errors.Is(err, ErrMismatchedDigest) {
+		t.Fatalf("Verify() error = %v, want %v", err, ErrMismatchedDigest)
+	}
+	// call vr.Verify again, the result should be the same
+	if err := vr.Verify(); !errors.Is(err, ErrMismatchedDigest) {
+		t.Fatalf("2nd Verify() error = %v, want %v", err, ErrMismatchedDigest)
+	}
+}
+
 func TestReadAll_CorrectDescriptor(t *testing.T) {
 	content := []byte("example content")
 	desc := NewDescriptorFromBytes("test", content)
+	r := bytes.NewReader([]byte(content))
+	got, err := ReadAll(r, desc)
+	if err != nil {
+		t.Fatal("ReadAll() error = ", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("ReadAll() = %v, want %v", got, content)
+	}
+}
+
+func TestReadAll_CorrectDescriptor_Resume(t *testing.T) {
+	content := []byte("example content")
+	desc := ocispec.Descriptor{
+		MediaType: "test",
+		Digest:    digest.FromBytes(content),
+		Size:      int64(len(content)),
+		Annotations: map[string]string{
+			spec.AnnotationResumeDownload: "true",
+			spec.AnnotationResumeOffset:   "3",
+		},
+	}
 	r := bytes.NewReader([]byte(content))
 	got, err := ReadAll(r, desc)
 	if err != nil {
@@ -175,12 +401,48 @@ func TestReadAll_ReadSizeSmallerThanDescriptorSize(t *testing.T) {
 	}
 }
 
+func TestReadAll_ReadSizeSmallerThanDescriptorSize_Resume(t *testing.T) {
+	content := []byte("example content")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromBytes(content),
+		Size:      int64(len(content) + 1),
+		Annotations: map[string]string{
+			spec.AnnotationResumeDownload: "true",
+			spec.AnnotationResumeOffset:   "3",
+		},
+	}
+	r := bytes.NewReader([]byte(content))
+	_, err := ReadAll(r, desc)
+	if err == nil || !errors.Is(err, io.EOF) {
+		t.Errorf("ReadAll() error = %v, want %v", err, io.EOF)
+	}
+}
+
 func TestReadAll_ReadSizeLargerThanDescriptorSize(t *testing.T) {
 	content := []byte("example content")
 	desc := ocispec.Descriptor{
 		MediaType: ocispec.MediaTypeImageLayer,
 		Digest:    digest.FromBytes(content),
 		Size:      int64(len(content) - 1)}
+	r := bytes.NewReader([]byte(content))
+	_, err := ReadAll(r, desc)
+	if err == nil || !errors.Is(err, ErrTrailingData) {
+		t.Errorf("ReadAll() error = %v, want %v", err, ErrTrailingData)
+	}
+}
+
+func TestReadAll_ReadSizeLargerThanDescriptorSize_Resume(t *testing.T) {
+	content := []byte("example content")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromBytes(content),
+		Size:      int64(len(content) - 1),
+		Annotations: map[string]string{
+			spec.AnnotationResumeDownload: "true",
+			spec.AnnotationResumeOffset:   "3",
+		},
+	}
 	r := bytes.NewReader([]byte(content))
 	_, err := ReadAll(r, desc)
 	if err == nil || !errors.Is(err, ErrTrailingData) {
@@ -198,9 +460,48 @@ func TestReadAll_InvalidDigest(t *testing.T) {
 	}
 }
 
+func TestReadAll_InvalidDigest_Resume(t *testing.T) {
+	content := []byte("example content")
+	desc := ocispec.Descriptor{
+		MediaType: "test",
+		Digest:    digest.FromBytes([]byte("another content")),
+		Size:      int64(len(content)),
+		Annotations: map[string]string{
+			spec.AnnotationResumeDownload: "true",
+			spec.AnnotationResumeOffset:   "3",
+		},
+	}
+	r := bytes.NewReader([]byte(content))
+	_, err := ReadAll(r, desc)
+	if err == nil || !errors.Is(err, ErrMismatchedDigest) {
+		t.Errorf("ReadAll() error = %v, want %v", err, ErrMismatchedDigest)
+	}
+}
+
 func TestReadAll_EmptyContent(t *testing.T) {
 	content := []byte("")
 	desc := NewDescriptorFromBytes("test", content)
+	r := bytes.NewReader([]byte(content))
+	got, err := ReadAll(r, desc)
+	if err != nil {
+		t.Fatal("ReadAll() error = ", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("ReadAll() = %v, want %v", got, content)
+	}
+}
+
+func TestReadAll_EmptyContent_Resume(t *testing.T) {
+	content := []byte("")
+	desc := ocispec.Descriptor{
+		MediaType: "test",
+		Digest:    digest.FromBytes(content),
+		Size:      int64(len(content)),
+		Annotations: map[string]string{
+			spec.AnnotationResumeDownload: "true",
+			spec.AnnotationResumeOffset:   "3",
+		},
+	}
 	r := bytes.NewReader([]byte(content))
 	got, err := ReadAll(r, desc)
 	if err != nil {
@@ -222,5 +523,44 @@ func TestReadAll_InvalidDescriptorSize(t *testing.T) {
 	_, err := ReadAll(r, desc)
 	if err == nil || !errors.Is(err, ErrInvalidDescriptorSize) {
 		t.Errorf("ReadAll() error = %v, want %v", err, ErrInvalidDescriptorSize)
+	}
+}
+
+func TestReadAll_InvalidDescriptorSize_Resume(t *testing.T) {
+	content := []byte("example content")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromBytes(content),
+		Size:      -1,
+		Annotations: map[string]string{
+			spec.AnnotationResumeDownload: "true",
+			spec.AnnotationResumeOffset:   "3",
+		},
+	}
+	r := bytes.NewReader([]byte(content))
+	_, err := ReadAll(r, desc)
+	if err == nil || !errors.Is(err, ErrInvalidDescriptorSize) {
+		t.Errorf("ReadAll() error = %v, want %v", err, ErrInvalidDescriptorSize)
+	}
+}
+
+func TestEncodeDecodeHash(t *testing.T) {
+	content := []byte("example content")
+
+	d := digest.FromBytes(content)
+	eh, err := EncodeHash(d.Algorithm().Hash())
+	if err != nil {
+		t.Fatal("EncodeHash failed =", err)
+	}
+	if eh == "" {
+		t.Fatal("EncodeHash returned empty")
+	}
+
+	dh, err := DecodeHash(eh, d)
+	if err != nil {
+		t.Fatal("DecodeHash failed =", err)
+	}
+	if !reflect.DeepEqual(dh, d.Algorithm().Hash()) {
+		t.Fatalf("EncodeHash/DecodeHash error = %v, want %v", dh, d.Algorithm().Hash())
 	}
 }

--- a/content/storage.go
+++ b/content/storage.go
@@ -60,6 +60,12 @@ type Deleter interface {
 	Delete(ctx context.Context, target ocispec.Descriptor) error
 }
 
+// Resumer knows how to do resumable downloads
+type Resumer interface {
+	// IngestFile returns the name of temporary ingest files
+	IngestFile(name string) string
+}
+
 // FetchAll safely fetches the content described by the descriptor.
 // The fetched content is verified against the size and the digest.
 func FetchAll(ctx context.Context, fetcher Fetcher, desc ocispec.Descriptor) ([]byte, error) {

--- a/content/verifiers.go
+++ b/content/verifiers.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2019, 2020 OCI Contributors
+Copyright 2017 Docker, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package content
+
+import (
+	"hash"
+
+	"github.com/opencontainers/go-digest"
+)
+
+// Verifier returns a writer object that can be used to verify a stream of
+// content against the digest. If the digest is invalid, the method will panic.
+func Verifier(d digest.Digest) digest.Verifier {
+	return hashVerifier{
+		hash:   d.Algorithm().Hash(),
+		digest: d,
+	}
+}
+
+// Copied from https://github.com/opencontainers/go-digest/blob/master/verifiers.go
+// Since hashVerifier is non-public in go-digest and we need to supply a pre-initialized
+// Hash we'll just make our own. Thank you Verifier interface!
+
+type hashVerifier struct {
+	digest digest.Digest
+	hash   hash.Hash
+}
+
+func (hv hashVerifier) Write(p []byte) (n int, err error) {
+	return hv.hash.Write(p)
+}
+
+func (hv hashVerifier) Verified() bool {
+	return hv.digest == digest.NewDigest(hv.digest.Algorithm(), hv.hash)
+}

--- a/content/verifiers_test.go
+++ b/content/verifiers_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package content
+
+import (
+	"bytes"
+	"crypto/rand"
+	_ "crypto/sha256"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+)
+
+// Copied from https://github.com/opencontainers/go-digest/blob/master/digest.go
+
+// FromBytes digests the input and returns a Digest.
+func FromBytes(p []byte) digest.Digest {
+	return digest.Canonical.FromBytes(p)
+}
+
+// Copied from https://github.com/opencontainers/go-digest/blob/master/verifiers_test.go
+
+func TestDigestVerifier(t *testing.T) {
+	p := make([]byte, 1<<20)
+	rand.Read(p)
+	content := FromBytes(p)
+
+	verifier := content.Verifier()
+
+	io.Copy(verifier, bytes.NewReader(p))
+
+	if !verifier.Verified() {
+		t.Fatalf("bytes not verified")
+	}
+}
+
+// TestVerifierUnsupportedDigest ensures that unsupported digest validation is
+// flowing through verifier creation.
+func TestVerifierUnsupportedDigest(t *testing.T) {
+	for _, testcase := range []struct {
+		Name     string
+		Digest   digest.Digest
+		Expected interface{} // expected panic target
+	}{
+		{
+			Name:     "Empty",
+			Digest:   "",
+			Expected: "no ':' separator in digest \"\"",
+		},
+		{
+			Name:     "EmptyAlg",
+			Digest:   ":",
+			Expected: "empty digest algorithm, validate before calling Algorithm.Hash()",
+		},
+		{
+			Name:     "Unsupported",
+			Digest:   digest.Digest("bean:0123456789abcdef"),
+			Expected: "bean not available (make sure it is imported)",
+		},
+		{
+			Name:     "Garbage",
+			Digest:   digest.Digest("sha256-garbage:pure"),
+			Expected: "sha256-garbage not available (make sure it is imported)",
+		},
+	} {
+		t.Run(testcase.Name, func(t *testing.T) {
+			expected := testcase.Expected
+			defer func() {
+				recovered := recover()
+				if !reflect.DeepEqual(recovered, expected) {
+					t.Fatalf("unexpected recover: %v != %v", recovered, expected)
+				}
+			}()
+
+			_ = testcase.Digest.Verifier()
+		})
+	}
+}

--- a/copy.go
+++ b/copy.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"strconv"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/semaphore"
@@ -29,6 +31,7 @@ import (
 	"oras.land/oras-go/v2/internal/descriptor"
 	"oras.land/oras-go/v2/internal/platform"
 	"oras.land/oras-go/v2/internal/registryutil"
+	"oras.land/oras-go/v2/internal/spec"
 	"oras.land/oras-go/v2/internal/status"
 	"oras.land/oras-go/v2/internal/syncutil"
 	"oras.land/oras-go/v2/registry"
@@ -346,6 +349,30 @@ func mountOrCopyNode(ctx context.Context, src content.ReadOnlyStorage, dst conte
 
 // doCopyNode copies a single content from the source CAS to the destination CAS.
 func doCopyNode(ctx context.Context, src content.ReadOnlyStorage, dst content.Storage, desc ocispec.Descriptor) error {
+	// We don't resume on files without Annotations
+	if desc.Annotations != nil {
+		// Get ingest path from dst if it is a local store
+		var ingestFile string
+		var ingestFileSize int64
+		if st, ok := dst.(content.Resumer); ok {
+			// Look for matching partial ingest files
+			ingestFile = st.IngestFile(desc.Digest.Encoded())
+			if ingestFile != "" {
+				// Found existing ingest file
+				f, err := os.Stat(ingestFile)
+				if err != nil {
+					// Can't find it???  Shouldn't happen...
+					ingestFile = ""
+				} else {
+					ingestFileSize = f.Size()
+					desc.Annotations[spec.AnnotationResumeOffset] = strconv.FormatInt(ingestFileSize, 10)
+					desc.Annotations[spec.AnnotationResumeFilename] = ingestFile
+					desc.Annotations[spec.AnnotationResumeDownload] = "true"
+				}
+			}
+		}
+	}
+
 	rc, err := src.Fetch(ctx, desc)
 	if err != nil {
 		return err

--- a/internal/spec/artifact.go
+++ b/internal/spec/artifact.go
@@ -26,6 +26,23 @@ const (
 
 	// AnnotationReferrersFiltersApplied is the annotation key for the comma separated list of filters applied by the registry in the referrers listing.
 	AnnotationReferrersFiltersApplied = "org.opencontainers.referrers.filtersApplied"
+
+	// The AnnotationResume* constants define the keys used in resumable downloads
+	// in the ocispec.Descriptior.Annotations map for tracking resume state.
+
+	// AnnotationResumeDownload is "true" when a resumable download is being attempted.
+	AnnotationResumeDownload = "com.salad.image.resume"
+
+	// AnnotationResumeFilename contains the full ingest filename.
+	AnnotationResumeFilename = "com.salad.image.resume.filename"
+
+	// AnnotationResumeHash contains a hash.Hash of the existing ingest file
+	// suitable for using in the new Verifier to resume download verification.
+	AnnotationResumeHash = "com.salad.image.resume.hash"
+
+	// AnnotationResumeOffset contains the resume download offset, aka
+	// the size of the existing ingest file.
+	AnnotationResumeOffset = "com.salad.image.resume.offset"
 )
 
 // MediaTypeArtifactManifest specifies the media type for a content descriptor.

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -264,6 +264,18 @@ func (r *Repository) do(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
+// FetcherHead fetches content headers.
+type FetcherHead interface {
+	// Fetch fetches the content identified by the descriptor.
+	FetchHead(ctx context.Context, target ocispec.Descriptor) (*http.Header, error)
+}
+
+// BlobStoreHead is a BlobStore with the ability to retrieve content headers.
+type BlobStoreHead interface {
+	registry.BlobStore
+	FetcherHead
+}
+
 // blobStore detects the blob store for the given descriptor.
 func (r *Repository) blobStore(desc ocispec.Descriptor) registry.BlobStore {
 	if isManifest(r.ManifestMediaTypes, desc) {
@@ -275,6 +287,15 @@ func (r *Repository) blobStore(desc ocispec.Descriptor) registry.BlobStore {
 // Fetch fetches the content identified by the descriptor.
 func (r *Repository) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
 	return r.blobStore(target).Fetch(ctx, target)
+}
+
+// FetchHead fetches the content headers identified by the descriptor.
+func (r *Repository) FetchHead(ctx context.Context, target ocispec.Descriptor) (*http.Header, error) {
+	bs := r.blobStore(target)
+	if bsh, ok := bs.(BlobStoreHead); ok {
+		return bsh.FetchHead(ctx, target)
+	}
+	return nil, fmt.Errorf("not a blobStore")
 }
 
 // Push pushes the content, matching the expected descriptor.
@@ -728,6 +749,82 @@ func (s *blobStore) Fetch(ctx context.Context, target ocispec.Descriptor) (rc io
 		return nil, err
 	}
 
+	var ingestSize int64
+	resume := target.Annotations != nil && target.Annotations[spec.AnnotationResumeDownload] == "true"
+	if resume {
+
+		// Check if resume is possible
+		_, err = s.FetchHead(ctx, target)
+		if err != nil {
+			// Resume is not possible, ensure it is disabled
+			if target.Annotations != nil {
+				target.Annotations[spec.AnnotationResumeDownload] = ""
+				resume = false
+			}
+		}
+
+		// Get size of existing ingestFile to set Range start
+		ingestSize, err = strconv.ParseInt(target.Annotations[spec.AnnotationResumeOffset], 10, 64)
+		if err != nil {
+			ingestSize = 0
+			resume = false
+		} else {
+			if ingestSize < target.Size {
+				// Set the Range header and do a chunk right up front if the file is not complete...
+				req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", ingestSize, target.Size-1))
+			}
+		}
+	}
+
+	resp, err := s.repo.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusPartialContent:
+		if size := resp.ContentLength; size != -1 && size != target.Size-ingestSize {
+			return nil, fmt.Errorf("206 %s %q: mismatch Content-Length", resp.Request.Method, resp.Request.URL)
+		}
+		return resp.Body, nil
+	case http.StatusOK:
+		if size := resp.ContentLength; size != -1 && size != target.Size {
+			return nil, fmt.Errorf("204 %s %q: mismatch Content-Length", resp.Request.Method, resp.Request.URL)
+		}
+
+		// check server range request capability.
+		// Docker spec allows range header form of "Range: bytes=<start>-<end>".
+		// However, the remote server may still not RFC 7233 compliant.
+		// Reference: https://docs.docker.com/registry/spec/api/#blob
+		if rangeUnit := resp.Header.Get("Accept-Ranges"); !resume && rangeUnit == "bytes" {
+			return httputil.NewReadSeekCloser(s.repo.client(), req, resp.Body, target.Size), nil
+		}
+		return resp.Body, nil
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("%s: %w", target.Digest, errdef.ErrNotFound)
+	default:
+		return nil, errutil.ParseErrorResponse(resp)
+	}
+}
+
+// FetchHead fetches the content identified by the descriptor.
+func (s *blobStore) FetchHead(ctx context.Context, target ocispec.Descriptor) (header *http.Header, err error) {
+	ref := s.repo.Reference
+	ref.Reference = target.Digest.String()
+	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
+	url := buildRepositoryBlobURL(s.repo.PlainHTTP, ref)
+
+	// HEAD
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	resp, err := s.repo.do(req)
 	if err != nil {
 		return nil, err
@@ -749,14 +846,18 @@ func (s *blobStore) Fetch(ctx context.Context, target ocispec.Descriptor) (rc io
 		// However, the remote server may still not RFC 7233 compliant.
 		// Reference: https://docs.docker.com/registry/spec/api/#blob
 		if rangeUnit := resp.Header.Get("Accept-Ranges"); rangeUnit == "bytes" {
-			return httputil.NewReadSeekCloser(s.repo.client(), req, resp.Body, target.Size), nil
+			if target.Annotations != nil {
+				target.Annotations[spec.AnnotationResumeDownload] = "true"
+			}
 		}
-		return resp.Body, nil
+		header = &resp.Header
 	case http.StatusNotFound:
 		return nil, fmt.Errorf("%s: %w", target.Digest, errdef.ErrNotFound)
 	default:
 		return nil, errutil.ParseErrorResponse(resp)
 	}
+
+	return header, nil
 }
 
 // Mount mounts the given descriptor from fromRepo into s.


### PR DESCRIPTION
These commits add resumable download capability to oras-go's Copy() method.

- Annotations key declarations (internal/spec/artifact.go)
  - Constants for the Annotations map used by resumable downloads
- Copy hashVerifier from go-digest
  - hashVerifier is non-public in go-digest and we need to supply a pre-initialized Hash
- Add resume to VerifyReader and add hashVerifier (content/reader.go)
  - Add resume field to VerifyReader to track resume mode
  - Skip setting UnexpectedEOF error in Read() in resume mode
  - Add hashVerifier from digest
  - Recover serialized Hash object in NewVerifyReader and create a content.hashVerifier if in resume mode
  - Duplicate tests for resume mode
- Add Store.IngestFile() and Storage.IngestFile() (content/oci/storage.go)
  - injest(): calculate hash on existing ingest file contents
- Add Repository.FetchHead() and friends (registry/remote/repository.go)
  - BlobStoreHead.FetchHead()
  - Repository.FetchHead()
  - blobStore.Fetch() checks for Range header support and sets it if so
- Updates to CopyBuffer (internal/ioutil/io.go)
  - Handle partial copies in CopyBuffer()
  - Add tests (upstream TestUnwrapNopCloser(0 is failing, not fixed here)
- Set up resume in doCopyNode() (copy.go)
  - Look for a partial downloaded file
  - Get headers from src to verify Range: support
  - Set up resume arguments in desc.Annotations
